### PR TITLE
fix: use https on submodules instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "atoms-core"]
 	path = atoms-core
-	url = git@github.com:AtomsDevs/atoms-core.git
+	url = https://github.com/AtomsDevs/atoms-core.git
 
 [submodule "atoms-cli"]
 	path = atoms-cli
-	url = git@github.com:AtomsDevs/atoms-cli.git
+	url = https://github.com/AtomsDevs/atoms-cli.git
 	
 [submodule "servicectl"]
 	path = servicectl


### PR DESCRIPTION
I found that in GitHub desktop and git itself atoms-cli and atoms-core could not be clone when pulling the submodules saying I did not have permission to do so and switching to https fixed this issue for me.