### PR TITLE
Fixed typo on template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,7 +35,7 @@ body:
     id: package
     attributes:
       label: Package
-      description: How did you install Bottles?
+      description: How did you install Atoms?
       options:
         - Flatpak from Flathub
         - From source


### PR DESCRIPTION
Probably during the reuse of the template of bottles someone forgot to change the app name.
Opening an bug report just for this is kinda dumb so I did it.